### PR TITLE
docs: macOS Gatekeeper bypass for pre-built releases

### DIFF
--- a/.github/release-notes-macos.md
+++ b/.github/release-notes-macos.md
@@ -1,0 +1,38 @@
+<!--
+  macOS install note appended to every GitHub release by .github/workflows/release.yml.
+
+  根因：开源项目没有 Apple Developer ID 证书 → `package.json` 的 `build.mac.identity = null`
+  → 打包产物既无签名也无公证 → macOS Catalina+ 浏览器/下载器会打 `com.apple.quarantine` 扩展属性
+  → Gatekeeper + XProtect 在 macOS Sequoia (15) 对完全未签名的隔离 App 走最严路径：
+    弹"XProtect 检查了它认为是恶意软件的项目"，并自动移到废纸篓。
+
+  这是 Gatekeeper 的标准误报，与代码无关。下面只解释怎么绕过，不解释原理，
+  原理请看仓库 README 的 macOS 安装小节。
+-->
+
+---
+
+## 📦 macOS 安装提示
+
+> **macOS 用户必读：** PurrCat 桌面端 **暂未做 Apple Developer ID 签名与公证**（项目是开源的，没有付费证书）。从 macOS Catalina 起 —— 尤其 **macOS Sequoia (15)** —— 打开下载的 `.app` 时可能被 **XProtect** 直接视为恶意程序并自动移到废纸篓（提示类似 "PurrCat will damage your computer"）。**这是 Gatekeeper 因缺失签名产生的误报，与代码无关。**
+
+### 首次运行：二选一
+
+**方案 A — 终端一行命令去除隔离标签（推荐）：**
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/PurrCat.app"
+open "/Applications/PurrCat.app"
+```
+
+每发一个新版本都需要重新执行一次。
+
+**方案 B — 不开终端，首次启动手动信任：**
+
+1. 把 `PurrCat.app` 从 dmg 拖进 `/Applications`。
+2. 在 Finder 中 **右键**（或按住 Control 点击）应用 → **打开**。
+3. 在系统弹窗里点 **打开**。之后再次双击即可正常启动。
+
+### 详细说明与原理
+
+见 [README 的 macOS 安装小节](../../blob/v${VERSION}/README.md#-installing-a-pre-built-release-macos)（含长期解决方案说明：正式签名 + 公证需要注册 Apple Developer 账号，$99/年）。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,17 +105,30 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          
+
           RELEASE_NOTES=$(awk -v version="$VERSION" '
             $0 == "## [" version "]" { in_section = 1; next }
             /^## / && in_section { exit }
             in_section { print }
           ' CHANGELOG.md)
-          
+
           if [ -z "$RELEASE_NOTES" ]; then
             RELEASE_NOTES="Release $VERSION"
           fi
-          
+
+          # 🌟 macOS 临时绕过提示：项目尚未做签名+公证，用户首次打开可能被 XProtect
+          #    扔进废纸篓。固定从仓库内文件读取拼到 release notes 末尾，保证用户
+          #    在下载页就能看到、不会漏掉；更新版本号占位符为本次发版号；
+          #    文件不可用时整个跳过，不要让 release 卡死。
+          if [ -f .github/release-notes-macos.md ]; then
+            MACOS_NOTE=$(sed "s/\${VERSION}/$VERSION/g" .github/release-notes-macos.md)
+            # 单行拼避免 YAML literal block 把内容提前 end 掉
+            FULL_NOTES=$(printf '%s\n\n%s' "$RELEASE_NOTES" "$MACOS_NOTE")
+          else
+            echo "::warning::.github/release-notes-macos.md not found, skipping macOS note"
+            FULL_NOTES="$RELEASE_NOTES"
+          fi
+
           # 🌟 GitHub API 不允许 prerelease 标记 Latest（HTTP 422:
           # "Latest release cannot be draft or prerelease"）。
           # beta 版想挂 Latest 必须做成完整发布，"beta" 只留在版本号里（OpenClaw 等项目的做法）；
@@ -123,20 +136,22 @@ jobs:
           IS_ALPHA=$([ "${{ inputs.release_type }}" = "alpha" ] && echo true || echo false)
 
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists"
+            echo "Release $TAG already exists, refreshing notes"
             if [ "$IS_ALPHA" = "false" ]; then
-              gh release edit "$TAG" --prerelease=false --latest
+              gh release edit "$TAG" --prerelease=false --latest --notes "$FULL_NOTES"
+            else
+              gh release edit "$TAG" --prerelease --notes "$FULL_NOTES"
             fi
           else
             if [ "$IS_ALPHA" = "true" ]; then
               gh release create "$TAG" \
                 --title "PurrCat $VERSION" \
-                --notes "$RELEASE_NOTES" \
+                --notes "$FULL_NOTES" \
                 --prerelease
             else
               gh release create "$TAG" \
                 --title "PurrCat $VERSION" \
-                --notes "$RELEASE_NOTES" \
+                --notes "$FULL_NOTES" \
                 --latest
             fi
           fi

--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ uv run python main.py --api --headless       # Open http://localhost:8000 in a b
 
 > Note: several features (local file access, terminal, etc.) depend on the Electron runtime and may misbehave in a plain browser. The desktop client is recommended for full functionality.
 
+## 📦 Installing a pre-built release (macOS)
+
+> **Heads-up for macOS users:** PurrCat desktop builds are **not yet signed or notarized** with an Apple Developer ID (the project is open source and does not own a paid certificate). On macOS Catalina and later — especially **macOS Sequoia (15)** — opening an unsigned `.app` downloaded from the internet can trigger **XProtect**, which may quarantine the app and move it to the Trash with a "PurrCat will damage your computer" / "malware" warning. **This is a false positive driven by the missing signature, not by anything in the code.**
+
+### Workarounds (pick one)
+
+**Option A — Strip the quarantine flag (recommended, one-liner):**
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/PurrCat.app"
+open "/Applications/PurrCat.app"
+```
+
+You will need to repeat this after installing each new release, because every freshly downloaded `.app` ships with a new quarantine attribute.
+
+**Option B — Trust on first launch (no terminal):**
+
+1. Drag `PurrCat.app` out of the DMG into `/Applications` as usual.
+2. In Finder, **right-click** (or Control-click) the app → choose **Open**.
+3. Click **Open** in the system dialog. From the next launch on, double-clicking works as normal.
+
+### Long-term fix
+
+Apple Developer ID signing + notarization (requires a registered Apple Developer account, $99/year). The root cause lives in `package.json` → `build.mac.identity` and `.github/workflows/release.yml` → `CSC_IDENTITY_AUTO_DISCOVERY: false`. Tracked as a follow-up; community PRs welcome.
+
 ## Architecture
 
 ### 01 Hybrid Memory and Knowledge Graph

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,31 @@ uv run python main.py --api --headless       # 浏览器打开 http://localhost:
 
 > 注：本地文件操作、终端等功能依赖 Electron 运行时，纯浏览器模式下可能出现异常。建议使用桌面端获得完整体验。
 
+## 📦 安装预编译版本（macOS 必读）
+
+> **macOS 用户注意：** PurrCat 桌面端目前 **未做 Apple Developer ID 签名与公证**（项目是开源的，没有付费证书）。从 macOS Catalina 起 —— 尤其是 **macOS Sequoia (15)** —— 打开从互联网下载的未签名 `.app`，会被 **XProtect** 直接视为恶意程序并自动移动到废纸篓，提示类似 "PurrCat will damage your computer"。**这是 Gatekeeper 因缺失签名产生的误报，跟代码本身没有关系。**
+
+### 临时绕过方案（二选一）
+
+**方案 A —— 终端一行命令去除隔离标签（推荐）：**
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/PurrCat.app"
+open "/Applications/PurrCat.app"
+```
+
+注意：每发一个新版本都需要重新执行一次，因为每次重新下载都会重新打上 `com.apple.quarantine` 扩展属性。
+
+**方案 B —— 不开终端，首次启动手动信任：**
+
+1. 把 `PurrCat.app` 从 dmg 拖进 `/Applications`。
+2. 在 Finder 里 **右键**（或按住 Control 点击）应用图标 → 选择 **打开**。
+3. 在系统弹窗里点 **打开**。之后再次双击即可正常启动。
+
+### 长期方案
+
+正式签名 + 公证需要注册 Apple Developer 账号（$99/年）。根因在 `package.json` → `build.mac.identity` 和 `.github/workflows/release.yml` → `CSC_IDENTITY_AUTO_DISCOVERY: false` 这两处，欢迎社区提 PR。
+
 ## 架构
 
 ### 01 混合记忆与知识图谱


### PR DESCRIPTION
## Why

PurrCat desktop builds are not signed / notarized (open-source project, no Apple Developer ID). On macOS Catalina+ (especially Sequoia / 15) the downloaded `.app` triggers XProtect and gets moved to the Trash with a malware warning. False positive caused entirely by the missing signature — nothing to do with the code.

## What

Docs-only change. Documents the situation and provides two stop-gap workarounds (`xattr` one-liner and Finder right-click → Open) so end users can launch the app today, without the project buying a paid cert.

## Files

- `README.md` / `README.zh-CN.md`: new "📦 Installing a pre-built release (macOS)" section explaining the issue and both workarounds.
- `.github/release-notes-macos.md`: shared snippet appended to every release body so users see it on the GitHub release page directly, not just in the repo README. Uses a `${VERSION}` placeholder filled in by the workflow.
- `.github/workflows/release.yml`: in the `publish` job, prepend the macOS note to `gh release create` / `gh release edit --notes`. Falls back gracefully (with a `::warning::`) if the snippet file is missing — never blocks a release.

## Long-term

Apple Developer ID + notarization ($99/year). Follow-up issue coming. The macOS note itself points users to the `package.json` `build.mac.identity` and `release.yml` `CSC_IDENTITY_AUTO_DISCOVERY` lines that need to change for the proper fix.

## Risk

Zero runtime risk — only docs and one CI step. The CI change updates `gh release edit --notes`, which is idempotent. The new step is guarded by `[ -f .github/release-notes-macos.md ]` so a missing file does not break release automation.